### PR TITLE
Fix listitem font to fit better on phone's UI

### DIFF
--- a/.ubuntu-sdk-deploy/components/PocketHome.qml
+++ b/.ubuntu-sdk-deploy/components/PocketHome.qml
@@ -151,7 +151,7 @@ Item {
                     id: itemtitle
                     text: title
                     wrapMode: Text.WordWrap
-                    font.pointSize: units.gu(1.5)
+                    font.pixelSize: FontUtils.sizeToPixels("medium")
                 }
                 Text {
                     anchors.top: itemtitle.bottom
@@ -162,7 +162,7 @@ Item {
                     id: itemdomain
                     text: domain
                     wrapMode: Text.WordWrap
-                    font.pointSize: units.gu(1.1)
+                    font.pixelSize: FontUtils.sizeToPixels("small")
                 }
                 Rectangle {
                     anchors.top: parent.top

--- a/components/PocketHome.qml
+++ b/components/PocketHome.qml
@@ -151,7 +151,7 @@ Item {
                     id: itemtitle
                     text: title
                     wrapMode: Text.WordWrap
-                    font.pointSize: units.gu(1.5)
+                    font.pixelSize: FontUtils.sizeToPixels("medium")
                 }
                 Text {
                     anchors.top: itemtitle.bottom
@@ -162,7 +162,7 @@ Item {
                     id: itemdomain
                     text: domain
                     wrapMode: Text.WordWrap
-                    font.pointSize: units.gu(1.1)
+                    font.pixelSize: FontUtils.sizeToPixels("small")
                 }
                 Rectangle {
                     anchors.top: parent.top


### PR DESCRIPTION
I noticed that after some upgrade on the phone, the font size in the list view was too big to fit into the view. After changing the grid units to literal definition, the font seems to be scaling fine. See before.png for the issue and after.png to see the result after the fix. Both screenshots have been taken on Meizu. 

The fix has been also tested by running the application from SDK in desktop mode.

Thanks for the great application and hopefully this pull request is useful.

![before](https://cloud.githubusercontent.com/assets/2667848/11938821/34a8fd9c-a826-11e5-99ed-5a5eeb2920b4.png)
![after](https://cloud.githubusercontent.com/assets/2667848/11938824/38febcce-a826-11e5-93d7-6cf4f5b9a516.png)
